### PR TITLE
Fix System.NullReferenceException on timer when dispose scheduler

### DIFF
--- a/src/CronJobService.cs
+++ b/src/CronJobService.cs
@@ -68,7 +68,7 @@ namespace CronJobExpress
 
         public void Dispose()
         {
-            _timer.Dispose();
+            _timer?.Dispose();
         }
 
         


### PR DESCRIPTION
If timer is null when scheduler is disposed, NullReferenceException is raised